### PR TITLE
Remove impl details in a file name

### DIFF
--- a/src/MonkeyCache/Barrel.cs
+++ b/src/MonkeyCache/Barrel.cs
@@ -37,7 +37,7 @@ namespace MonkeyCache
         Barrel()
         {
             var directory = baseCacheDir.Value;
-            string path = Path.Combine(directory, "Barrel.sqlite");
+            string path = Path.Combine(directory, "Barrel.db");
             if (!Directory.Exists(directory))
             {
                 Directory.CreateDirectory(directory);


### PR DESCRIPTION
Minor nit: don't leak the impl detail in a file name if you have two diff providers.  Just call it '.db' (or heck '.cache').