### PR TITLE
Added File based Barrel implementation

### DIFF
--- a/src/MonkeyCache.FileStore/MonkeyCache.FileStore.csproj
+++ b/src/MonkeyCache.FileStore/MonkeyCache.FileStore.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <PackageReference Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="Microsoft.NETCore.UniversalWindowsPlatform " Version="6.0.5" />
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.2-build.23" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MonkeyCache.TestsShared/BarrelTests.cs
+++ b/src/MonkeyCache.TestsShared/BarrelTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -288,6 +289,54 @@ namespace MonkeyCache.Tests
             barrel.EmptyAll();
 
             Assert.IsFalse(barrel.Exists(url));
+        }
+
+        #endregion
+
+#region Performance Tests
+        [TestMethod]
+        public void PerformanceTests()
+        {
+
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var keys = Enumerable.Range(0, 1000).Select(x => $"key-{x}").ToArray();
+
+            // Add a lot of items
+            foreach (var key in keys)
+                barrel.Add(key: key, data: monkeys, expireIn: TimeSpan.FromDays(1));
+            
+            stopwatch.Stop();
+            Debug.WriteLine($"Add took {stopwatch.ElapsedMilliseconds} ms");
+            stopwatch.Restart();
+
+            foreach (var key in keys) {
+                var content = barrel.Get(key);
+                Assert.IsNotNull(content);
+            }
+
+            stopwatch.Stop();
+            Debug.WriteLine($"Gets took {stopwatch.ElapsedMilliseconds} ms");
+            stopwatch.Restart();
+
+            foreach (var key in keys) {
+                var content = barrel.GetETag(key);
+                Assert.IsNotNull(content);
+            }
+
+            stopwatch.Stop();
+            Debug.WriteLine($"Get eTags took {stopwatch.ElapsedMilliseconds} ms");
+            stopwatch.Restart();
+
+            // Delete all
+            barrel.Empty(keys);
+
+            stopwatch.Stop();
+            Debug.WriteLine($"Empty took {stopwatch.ElapsedMilliseconds} ms");
+
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds > 1);
         }
 
 #endregion


### PR DESCRIPTION
This uses a simple index file to store a mapping of keys, expiration dates, and etag values for all the items in the cache.  The actual cache content is stored in files on disk with the filename being an MD5 hash of the cache key.

It also adds some simple performance tests which just simply adds and then gets and finally removes a bunch of items.  This should give some basic indication of the speed of the cache.  There's a few variations of the test, with a single thread, multithreading, and then multithreading with threads all working with the same set of cache keys so we can simulate some level of collisions between objects on threads.