### PR TITLE
Correct the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ async Task<IEnumerable<Monkey>> GetMonkeysAsync()
 
     //Dev handle online/offline scenario
     if(!CrossConnectivity.Current.IsConnected)
+    {
         return Barrel.Current.Get<IEnumerable<Monkey>>(key: url);
-
+    }
+    
     //Dev handles checking if cache is expired
     if(!Barrel.Current.IsExpired(key: url))
     {
@@ -57,7 +59,7 @@ async Task<IEnumerable<Monkey>> GetMonkeysAsync()
     var monkeys = JsonConvert.DeserializeObject<IEnumerable<Monkey>>(json);
 
     //Saves the cache and pass it a timespan for expiration
-    Barrel.Current.Add(key: url, data: monkeys, expiration: TimeSpan.FromDays(1));
+    Barrel.Current.Add(key: url, data: monkeys, expireIn: TimeSpan.FromDays(1));
 
 }
 ```


### PR DESCRIPTION
Corrected the expiration keyword.
Added brackets for consistency.    

The HttpCache.GetAsync I think is wrong too? I can't get it working. Think its meant to be the below.

return HttpCache.Current.GetCachedAsync(url: url, timeout: TimeSpan.FromSeconds(30), expireIn: TimeSpan.FromDays(1));

But I can't get it working with type arguments so I'm not sure? I can correct that if you point me in the right direction.

The one other thing I noticed is you use url here but key elsewhere. Should this be key too? If so I can create another issue and fix