### PR TITLE
Added extension method for cached http requests

### DIFF
--- a/src/MonkeyCache.TestsFileStore/HttpCacheTests.cs
+++ b/src/MonkeyCache.TestsFileStore/HttpCacheTests.cs
@@ -1,11 +1,9 @@
-﻿using MonkeyCache.FileStore;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using MonkeyCache.FileStore;
 
 namespace MonkeyCache.Tests
 {
-	public partial class BarrelTests
+	public partial class HttpCacheTests
 	{
 		void SetupBarrel()
 		{

--- a/src/MonkeyCache.TestsLiteDB/HttpCacheTests.cs
+++ b/src/MonkeyCache.TestsLiteDB/HttpCacheTests.cs
@@ -1,11 +1,9 @@
-﻿using MonkeyCache.FileStore;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using MonkeyCache.LiteDB;
 
 namespace MonkeyCache.Tests
 {
-	public partial class BarrelTests
+	public partial class HttpCacheTests
 	{
 		void SetupBarrel()
 		{

--- a/src/MonkeyCache.TestsSQLite/HttpCacheTests.cs
+++ b/src/MonkeyCache.TestsSQLite/HttpCacheTests.cs
@@ -1,11 +1,9 @@
-﻿using MonkeyCache.FileStore;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using MonkeyCache.SQLite;
 
 namespace MonkeyCache.Tests
 {
-	public partial class BarrelTests
+	public partial class HttpCacheTests
 	{
 		void SetupBarrel()
 		{

--- a/src/MonkeyCache.TestsShared/HttpCacheTests.cs
+++ b/src/MonkeyCache.TestsShared/HttpCacheTests.cs
@@ -1,4 +1,4 @@
-﻿/*using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -9,31 +9,22 @@ namespace MonkeyCache.Tests
 {
    
     [TestClass]
-    public class HttpCacheTests
+    public partial class HttpCacheTests
     {
-        IEnumerable<Monkey> monkeys;
         IBarrel barrel;
         string url;
-        string json;
+        
         [TestInitialize]
         public void Setup()
         {
-            Barrel.ApplicationId = "com.refractored.monkeycache";
-            var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            path = Path.Combine(path, Barrel.ApplicationId);
-            if (System.IO.File.Exists(path))
-                File.Delete(path);
+            SetupBarrel();
             url = "http://montemagno.com/monkeys.json";
-            barrel = Barrel.Current;
-
-            json = @"[{""Name"":""Baboon"",""Location"":""Africa & Asia"",""Details"":""Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae."",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/9\/96\/Portrait_Of_A_Baboon.jpg\/314px-Portrait_Of_A_Baboon.jpg"",""Population"":10000},{""Name"":""Capuchin Monkey"",""Location"":""Central & South America"",""Details"":""The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus."",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/4\/40\/Capuchin_Costa_Rica.jpg\/200px-Capuchin_Costa_Rica.jpg"",""Population"":23000},{""Name"":""Blue Monkey"",""Location"":""Central and East Africa"",""Details"":""The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia"",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/8\/83\/BlueMonkey.jpg\/220px-BlueMonkey.jpg"",""Population"":12000},{""Name"":""Squirrel Monkey"",""Location"":""Central & South America"",""Details"":""The squirrel monkeys are the New World monkeys of the genus Saimiri. They are the only genus in the subfamily Saimirinae. The name of the genus Saimiri is of Tupi origin, and was also used as an English name by early researchers."",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/2\/20\/Saimiri_sciureus-1_Luc_Viatour.jpg\/220px-Saimiri_sciureus-1_Luc_Viatour.jpg"",""Population"":11000},{""Name"":""Golden Lion Tamarin"",""Location"":""Brazil"",""Details"":""The golden lion tamarin also known as the golden marmoset, is a small New World monkey of the family Callitrichidae."",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/8\/87\/Golden_lion_tamarin_portrait3.jpg\/220px-Golden_lion_tamarin_portrait3.jpg"",""Population"":19000},{""Name"":""Howler Monkey"",""Location"":""South America"",""Details"":""Howler monkeys are among the largest of the New World monkeys. Fifteen species are currently recognised. Previously classified in the family Cebidae, they are now placed in the family Atelidae."",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/0\/0d\/Alouatta_guariba.jpg\/200px-Alouatta_guariba.jpg"",""Population"":8000},{""Name"":""Japanese Macaque"",""Location"":""Japan"",""Details"":""The Japanese macaque, is a terrestrial Old World monkey species native to Japan. They are also sometimes known as the snow monkey because they live in areas where snow covers the ground for months each"",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/c\/c1\/Macaca_fuscata_fuscata1.jpg\/220px-Macaca_fuscata_fuscata1.jpg"",""Population"":1000},{""Name"":""Mandrill"",""Location"":""Southern Cameroon, Gabon, Equatorial Guinea, and Congo"",""Details"":""The mandrill is a primate of the Old World monkey family, closely related to the baboons and even more closely to the drill. It is found in southern Cameroon, Gabon, Equatorial Guinea, and Congo."",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/7\/75\/Mandrill_at_san_francisco_zoo.jpg\/220px-Mandrill_at_san_francisco_zoo.jpg"",""Population"":17000},{""Name"":""Proboscis Monkey"",""Location"":""Borneo"",""Details"":""The proboscis monkey or long-nosed monkey, known as the bekantan in Malay, is a reddish-brown arboreal Old World monkey that is endemic to the south-east Asian island of Borneo."",""Image"":""http:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/e\/e5\/Proboscis_Monkey_in_Borneo.jpg\/250px-Proboscis_Monkey_in_Borneo.jpg"",""Population"":15000},{""Name"":""Sebastian"",""Location"":""Seattle"",""Details"":""This little trouble maker lives in Seattle with James and loves traveling on adventures with James and tweeting @MotzMonkeys. He by far is an Android fanboy and is getting ready for the new Nexus 6P!"",""Image"":""http:\/\/www.refractored.com\/images\/sebastian.jpg"",""Population"":1},{""Name"":""Henry"",""Location"":""Phoenix"",""Details"":""An adorable Monkey who is traveling the world with Heather and live tweets his adventures @MotzMonkeys. His favorite platform is iOS by far and is excited for the new iPhone 6s!"",""Image"":""http:\/\/www.refractored.com\/images\/henry.jpg"",""Population"":1}]";
-            monkeys = JsonConvert.DeserializeObject<IEnumerable<Monkey>>(json);
         }
 
         [TestMethod]
         public async Task GetCachedTest()
         {
-            var result = await HttpCache.Current.GetCachedAsync(url, TimeSpan.FromSeconds(60), TimeSpan.FromDays(1));
+            var result = await HttpCache.Current.GetCachedAsync(barrel, url, TimeSpan.FromSeconds(60), TimeSpan.FromDays(1));
 
             Assert.IsNotNull(result);
         }
@@ -41,12 +32,9 @@ namespace MonkeyCache.Tests
         [TestMethod]
         public async Task GetCachedForceTest()
         {
-            var result = await HttpCache.Current.GetCachedAsync(url, TimeSpan.FromSeconds(60), TimeSpan.FromDays(1), true);
+            var result = await HttpCache.Current.GetCachedAsync(barrel, url, TimeSpan.FromSeconds(60), TimeSpan.FromDays(1), true);
 
             Assert.IsNotNull(result);
         }
-
-
     }
 }
-*/

--- a/src/MonkeyCache/HttpCache.cs
+++ b/src/MonkeyCache/HttpCache.cs
@@ -6,112 +6,105 @@ using System.Threading.Tasks;
 
 namespace MonkeyCache
 {
-    public class HttpCache
-    {
+	public class HttpCache
+	{
 
-        static HttpCache instance = null;
+		static HttpCache instance = null;
 
-        /// <summary>
-        /// Gets the instance of the HttpCache
-        /// </summary>
-        public static HttpCache Current => (instance ?? (instance = new HttpCache()));
+		/// <summary>
+		/// Gets the instance of the HttpCache
+		/// </summary>
+		public static HttpCache Current => (instance ?? (instance = new HttpCache()));
 
-        HttpCache()
-        {
-        }
+		HttpCache()
+		{
+		}
 
-        internal HttpClient CreateClient(TimeSpan timeout)
-        {
-            var h = new HttpClientHandler
-            {
-                AllowAutoRedirect = true,
-                AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip,
-                MaxAutomaticRedirections = 20,
+		internal HttpClient CreateClient(TimeSpan timeout)
+		{
+			var h = new HttpClientHandler {
+				AllowAutoRedirect = true,
+				AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip,
+				MaxAutomaticRedirections = 20,
 
-            };
-            var cli = new HttpClient(h);
-            cli.Timeout = timeout;
-            return cli;
-        }
+			};
+			var cli = new HttpClient(h);
+			cli.Timeout = timeout;
+			return cli;
+		}
 
-        static System.Threading.SemaphoreSlim getThrottle = new System.Threading.SemaphoreSlim(4, 4);
+		public Task<string> GetCachedAsync(IBarrel barrel, string url, TimeSpan timeout, TimeSpan expireIn, bool forceUpdate = false, bool throttled = true)
+		{
+			var client = CreateClient(timeout);
 
-        public async Task<string> GetCachedAsync(IBarrel barrel, string url, TimeSpan timeout, TimeSpan expireIn, bool forceUpdate = false)
-        {
-            var contents = barrel.Get(url);
-            var eTag = barrel.GetETag(url);
+			return client.SendCachedAsync(barrel, new HttpRequestMessage(HttpMethod.Get, url), expireIn, forceUpdate, throttled);
+		}
+	}
 
-            if (!forceUpdate && !string.IsNullOrEmpty(contents) && !barrel.IsExpired(url))
-                return contents;
+	public static class HttpCacheExtensions
+	{
+		static System.Threading.SemaphoreSlim getThrottle = new System.Threading.SemaphoreSlim(4, 4);
 
-            var etag = eTag ?? null;
+		public static async Task<string> SendCachedAsync(this HttpClient http, IBarrel barrel, HttpRequestMessage req, TimeSpan expireIn, bool forceUpdate = false, bool throttled = true)
+		{
+			var url = req.RequestUri.ToString();
 
-            await getThrottle.WaitAsync();
+			var contents = barrel.Get(url);
+			var eTag = barrel.GetETag(url);
 
-            HttpResponseMessage r;
-            string c;
+			if (!forceUpdate && !string.IsNullOrEmpty(contents) && !barrel.IsExpired(url))
+				return contents;
 
-            try
-            {
+			var etag = eTag ?? null;
 
-                //Console.WriteLine("GetCachedAsync " + url + " etag: " + etag);
+			if (throttled)
+				await getThrottle.WaitAsync();
 
-                var client = CreateClient(timeout);
-                if (!forceUpdate && !string.IsNullOrEmpty(etag) && !string.IsNullOrEmpty(contents))
-                {
-                    client.DefaultRequestHeaders.IfNoneMatch.Clear();
-                    client.DefaultRequestHeaders.IfNoneMatch.Add(new EntityTagHeaderValue(etag));
-                }
+			HttpResponseMessage r;
+			string c = null;
 
-                r = await client.GetAsync(url);
+			try {
+				if (!forceUpdate && !string.IsNullOrEmpty(etag) && !string.IsNullOrEmpty(contents)) {
+					req.Headers.IfNoneMatch.Clear();
+					req.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(etag));
+				}
 
-                //Console.WriteLine("GotCachedAsync " + r.StatusCode);
+				r = await http.SendAsync(req);
 
-                if (r.StatusCode == HttpStatusCode.NotModified)
-                {
-                    if (string.IsNullOrEmpty(contents))
-                        throw new Exception("Cached value missing");
-                    
-                    return contents;
-                }
+				if (r.StatusCode == HttpStatusCode.NotModified) {
+					if (string.IsNullOrEmpty(contents))
+						throw new IndexOutOfRangeException($"Cached value missing for HTTP request: {url}");
 
-                if (r.StatusCode == HttpStatusCode.OK)
-                {
+					return contents;
+				}
 
-                    c = await r.Content.ReadAsStringAsync();
-                    if (!string.IsNullOrEmpty(c) && c[0] == 0xFEFF)
-                    {
-                        c = c.Substring(1);
-                    }
-                }
-                else
-                {
-                    c = "";
-                }
-            }
-            finally
-            {
-                getThrottle.Release();
-            }
+				c = await r.Content.ReadAsStringAsync();
+			} finally {
+				if (throttled)
+					getThrottle.Release();
+			}
 
-            if (r.StatusCode == HttpStatusCode.OK)
-            {
-                //
-                // Cache it?
-                //
-                var newEtag = r.Headers.ETag != null ? r.Headers.ETag.Tag : null;
-                if (!string.IsNullOrEmpty(newEtag) && newEtag != etag)
-                {
-                    //Console.WriteLine("CACHING " + url + " etag: " + etag);
-                    barrel.Add(url, c, expireIn, newEtag);
-                }
+			if (r.StatusCode == HttpStatusCode.OK) {
+				// Cache it?
+				var newEtag = r.Headers.ETag != null ? r.Headers.ETag.Tag : null;
+				if (!string.IsNullOrEmpty(newEtag) && newEtag != etag)
+					barrel.Add(url, c, expireIn, newEtag);
 
-                return c;
-            }
-            else
-            {
-                throw new Exception("Bad web response: " + r.StatusCode);
-            }
-        }
-    }
+				return c;
+			} else {
+				throw new HttpCacheRequestException(r.StatusCode, "HTTP Cache Request Failed");
+			}
+		}
+	}
+
+	public class HttpCacheRequestException : HttpRequestException
+	{
+		public HttpCacheRequestException (HttpStatusCode statusCode, string message) 
+			: base (message)
+		{
+			StatusCode = statusCode;
+		}
+
+		public HttpStatusCode StatusCode { get; private set; }
+	}
 }


### PR DESCRIPTION
This allows you to pass in any HttpRequestMessage and expect a string back (which is backed by the cache barrel), and takes into account an etag to send to the server.

Also added some tests back in for this.  I’ve kept the original GetCachedAsync method in tact.