### PR TITLE
Fix expiration checks where LiteDb converts to local time

### DIFF
--- a/src/MonkeyCache.LiteDB/Barrel.cs
+++ b/src/MonkeyCache.LiteDB/Barrel.cs
@@ -88,7 +88,7 @@ namespace MonkeyCache.LiteDB
             if (ent == null)
                 return true;
 
-            return DateTime.UtcNow > ent.ExpirationDate;
+            return DateTime.UtcNow > ent.ExpirationDate.ToUniversalTime();
         }
 
         #endregion
@@ -193,7 +193,7 @@ namespace MonkeyCache.LiteDB
         /// </summary>
         public void EmptyExpired()
         {
-            col.Delete(b => b.ExpirationDate < DateTime.UtcNow);
+            col.Delete(b => b.ExpirationDate.ToUniversalTime() < DateTime.UtcNow);
         }
 
         /// <summary>


### PR DESCRIPTION
The LiteDb package apparently converts dates to local time when they are retrieved, so items always appear to be expired when the expiration is less than the local UTC offset.