### PR TITLE
Put lids on the barrels

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ It is required that you set an ApplicationId for your application so a folder is
 Barrel.ApplicationId = "your_unique_name_here";
 ```
 
+You can optionally intercept data being put into or taken out of your barrel by assigning a lid to it. Lids are used to evaluate or modify data, or to cancel a barrel operation.  Create a lid by adding a class that implements the ILid interface, then assign it to Barrel's Lid property before calling ANY method:
+
+```
+Barrel.Lid = new TestLid();
+
+public class TestLid : ILid
+{
+	// Return null from either method to cancel the calling barrel's operation
+	
+	public string AddingToBarrel(string content) => Reverse(content);
+	public string GettingFromBarrel(string content) => Reverse(content);
+
+	string Reverse(string data)
+	{
+		var chars = data.ToCharArray();
+		Array.Reverse(chars);
+		return new string(chars);
+	}
+}
+```
 
 ### What is Monkey Cache?
 
@@ -178,5 +198,8 @@ Under MIT (see license file)
 
 ### Want To Support This Project?
 All I have ever asked is to be active by submitting bugs, features, and sending those pull requests down! Want to go further? Make sure to subscribe to my weekly development podcast [Merge Conflict](http://mergeconflict.fm), where I talk all about awesome Xamarin goodies and you can optionally support the show by becoming a [supporter on Patreon](https://www.patreon.com/mergeconflictfm).
+
+
+
 
 

--- a/src/MonkeyCache.TestsFileStore/BarrelTests.cs
+++ b/src/MonkeyCache.TestsFileStore/BarrelTests.cs
@@ -1,4 +1,5 @@
 ﻿using MonkeyCache.FileStore;
+using MonkeyCache.TestsShared;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -12,5 +13,9 @@ namespace MonkeyCache.Tests
 			Barrel.ApplicationId = "com.refractored.monkeyfile";
 			barrel = Barrel.Current;
 		}
+
+		void SetupLid() => Barrel.Lid = new TestLid();
+
+		bool LidWasUsed() => (Barrel.Lid as TestLid).WasUsed;
 	}
 }

--- a/src/MonkeyCache.TestsLiteDB/BarrelTests.cs
+++ b/src/MonkeyCache.TestsLiteDB/BarrelTests.cs
@@ -1,4 +1,5 @@
 ﻿using MonkeyCache.LiteDB;
+using MonkeyCache.TestsShared;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -12,5 +13,9 @@ namespace MonkeyCache.Tests
 			Barrel.ApplicationId = "com.refractored.monkeylite";
 			barrel = Barrel.Current;
 		}
+
+		void SetupLid() => Barrel.Lid = new TestLid();
+
+		bool LidWasUsed() => (Barrel.Lid as TestLid).WasUsed;
 	}
 }

--- a/src/MonkeyCache.TestsSQLite/BarrelTests.cs
+++ b/src/MonkeyCache.TestsSQLite/BarrelTests.cs
@@ -1,4 +1,5 @@
 ﻿using MonkeyCache.SQLite;
+using MonkeyCache.TestsShared;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -12,5 +13,9 @@ namespace MonkeyCache.Tests
 			Barrel.ApplicationId = "com.refractored.monkeysql";
 			barrel = Barrel.Current;
 		}
+
+		void SetupLid() => Barrel.Lid = new TestLid();
+
+		bool LidWasUsed() => (Barrel.Lid as TestLid).WasUsed;
 	}
 }

--- a/src/MonkeyCache.TestsShared/BarrelTests.cs
+++ b/src/MonkeyCache.TestsShared/BarrelTests.cs
@@ -45,6 +45,14 @@ namespace MonkeyCache.Tests
 
         }
 
+		[TestMethod]
+		public void GetStringWithLidTest()
+		{
+			SetupLid();
+			GetStringTest();
+			Assert.IsTrue(LidWasUsed());
+		}
+
         [TestMethod]
         public void GetTest()
         {
@@ -59,8 +67,16 @@ namespace MonkeyCache.Tests
 
         }
 
+		[TestMethod]
+		public void GetWithLidTest()
+		{
+			SetupLid();
+			GetTest();
+			Assert.IsTrue(LidWasUsed());
+		}
 
-        [TestMethod]
+
+		[TestMethod]
         public void GetETagTest()
         {
 
@@ -100,7 +116,15 @@ namespace MonkeyCache.Tests
 
         }
 
-        [TestMethod]
+		[TestMethod]
+		public void AddStringNullWithLidTest()
+		{
+			SetupLid();
+			AddStringNullTest();
+			Assert.IsFalse(LidWasUsed());
+		}
+
+		[TestMethod]
         public void AddStringTest()
         {
 
@@ -114,7 +138,15 @@ namespace MonkeyCache.Tests
 
         }
 
-        [TestMethod]
+		[TestMethod]
+		public void AddStringWithLidTest()
+		{
+			SetupLid();
+			AddStringTest();
+			Assert.IsTrue(LidWasUsed());
+		}
+
+		[TestMethod]
         public void AddNullTest()
         {
 
@@ -128,7 +160,15 @@ namespace MonkeyCache.Tests
 
         }
 
-        [TestMethod]
+		[TestMethod]
+		public void AddNullWithLidTest()
+		{
+			SetupLid();
+			AddNullTest();
+			Assert.IsFalse(LidWasUsed());
+		}
+
+		[TestMethod]
         public void AddTest()
         {
 
@@ -142,8 +182,15 @@ namespace MonkeyCache.Tests
 
         }
 
+		[TestMethod]
+		public void AddWithLidTest()
+		{
+			SetupLid();
+			AddTest();
+			Assert.IsTrue(LidWasUsed());
+		}
 
-        [TestMethod]
+		[TestMethod]
         public void AddTestNull()
         {
 
@@ -157,11 +204,19 @@ namespace MonkeyCache.Tests
 
         }
 
-        #endregion
+		[TestMethod]
+		public void AddTestWithLidNull()
+		{
+			SetupLid();
+			AddTestNull();
+			Assert.IsFalse(LidWasUsed());
+		}
 
-        #region Expiration Tests
+		#endregion
 
-        [TestMethod]
+		#region Expiration Tests
+
+		[TestMethod]
         public void IsExpiredNullTest()
         {
             Assert.IsTrue(barrel.IsExpired(url));

--- a/src/MonkeyCache.TestsShared/MonkeyCache.TestsShared.projitems
+++ b/src/MonkeyCache.TestsShared/MonkeyCache.TestsShared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)BarrelTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpCacheTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestLid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Monkey.cs" />
   </ItemGroup>
 </Project>

--- a/src/MonkeyCache.TestsShared/TestLid.cs
+++ b/src/MonkeyCache.TestsShared/TestLid.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace MonkeyCache.TestsShared
+{
+	public class TestLid : ILid
+	{
+		public bool WasUsed { get; set; }
+
+		public string AddingToBarrel(string content) => Reverse(content);
+
+		public string GettingFromBarrel(string content) => Reverse(content);
+
+		string Reverse(string data)
+		{
+			WasUsed = true;
+
+			var chars = data.ToCharArray();
+			Array.Reverse(chars);
+			return new string(chars);
+		}
+	}
+}

--- a/src/MonkeyCache/ILid.cs
+++ b/src/MonkeyCache/ILid.cs
@@ -1,0 +1,9 @@
+﻿namespace MonkeyCache
+{
+    public interface ILid
+    {
+		// Return null from either method to cancel the calling Barrel operation
+		string AddingToBarrel(string content);
+		string GettingFromBarrel(string content);
+    }
+}


### PR DESCRIPTION
- Added the ability to evaluate, modify and block data operations immediately before data is written to or read from a barrel's backing data store. Useful for integrating external operations with MonkeyCache, i.e., logging, data encryption, data filtering, etc.
- Modified existing, and added new, unit tests to take changes into account. All tests passing

To use the new feature, create a class that implements the new ILid interface and assign it to your datastore-specific Barrel class's new Lid property. The ILid interface requires implementations of the AddingToBarrel and GettingFromBarrel methods.  See the MonkeyCache.TestsShared.TestLid class for an example.

Return the string that was passed to the methods if no modifications are needed, or modify the received data as desired before returning the changes. Returning null from either method causes the associated Barrel operation to be aborted.