### PR TITLE
Allow Custom Cache Directory to be specified for Barrel

### DIFF
--- a/src/MonkeyCache.FileStore/Barrel.cs
+++ b/src/MonkeyCache.FileStore/Barrel.cs
@@ -13,9 +13,17 @@ namespace MonkeyCache.FileStore
 	{
 		ReaderWriterLockSlim indexLocker;
 		readonly JsonSerializerSettings jsonSettings;
+		Lazy<string> baseDirectory;
 
-		Barrel()
+		Barrel(string cacheDirectory = null)
 		{
+			baseDirectory = new Lazy<string>(() =>
+			{
+				return string.IsNullOrEmpty(cacheDirectory) ?
+					Path.Combine(BarrelUtils.GetBasePath(ApplicationId), "MonkeyCacheFS")
+					: cacheDirectory;
+			});
+
 			indexLocker = new ReaderWriterLockSlim();
 
 			jsonSettings = new JsonSerializerSettings
@@ -39,6 +47,9 @@ namespace MonkeyCache.FileStore
 		/// Gets the instance of the Barrel
 		/// </summary>
 		public static IBarrel Current => (instance ?? (instance = new Barrel()));
+
+		public static IBarrel Create(string cacheDirectory) =>
+			new Barrel(cacheDirectory);
 
 		/// <summary>
 		/// Adds an entry to the barrel
@@ -378,11 +389,6 @@ namespace MonkeyCache.FileStore
 
 			return expired;
 		}
-
-		Lazy<string> baseDirectory = new Lazy<string>(() =>
-		{
-			return Path.Combine(BarrelUtils.GetBasePath(ApplicationId), "MonkeyCacheFS");
-		});
 
 		Dictionary<string, Tuple<string, DateTime>> index;
 

--- a/src/MonkeyCache.LiteDB/Barrel.cs
+++ b/src/MonkeyCache.LiteDB/Barrel.cs
@@ -32,10 +32,13 @@ namespace MonkeyCache.LiteDB
 		/// </summary>
 		public static IBarrel Current => (instance ?? (instance = new Barrel()));
 
+		public static IBarrel Create(string cacheDirectory)
+			=> new Barrel(cacheDirectory);
+
 		readonly JsonSerializerSettings jsonSettings;
-		Barrel()
+		Barrel(string cacheDirectory = null)
 		{
-			var directory = baseCacheDir.Value;
+			var directory = string.IsNullOrEmpty(cacheDirectory) ? baseCacheDir.Value : cacheDirectory;
 			var path = Path.Combine(directory, "Barrel.db");
 			if (!Directory.Exists(directory))
 			{

--- a/src/MonkeyCache.SQLite/Barrel.cs
+++ b/src/MonkeyCache.SQLite/Barrel.cs
@@ -23,7 +23,6 @@ namespace MonkeyCache.SQLite
 		readonly SQLiteConnection db;
 		readonly object dblock = new object();
 
-
 		static Barrel instance = null;
 
 		/// <summary>
@@ -31,10 +30,13 @@ namespace MonkeyCache.SQLite
 		/// </summary>
 		public static IBarrel Current => (instance ?? (instance = new Barrel()));
 
+		public static IBarrel Create(string cacheDirectory)
+			=> new Barrel(cacheDirectory);
+
 		readonly JsonSerializerSettings jsonSettings;
-		Barrel()
+		Barrel(string cacheDirectory = null)
 		{
-			var directory = baseCacheDir.Value;
+			var directory = string.IsNullOrEmpty(cacheDirectory) ? baseCacheDir.Value : cacheDirectory;
 			var path = Path.Combine(directory, "Barrel.db");
 			if (!Directory.Exists(directory))
 			{

--- a/src/MonkeyCache.TestsFileStore/BarrelTests.cs
+++ b/src/MonkeyCache.TestsFileStore/BarrelTests.cs
@@ -7,10 +7,18 @@ namespace MonkeyCache.Tests
 {
 	public partial class BarrelTests
 	{
-		void SetupBarrel()
+		public virtual void SetupBarrel()
 		{
 			Barrel.ApplicationId = "com.refractored.monkeyfile";
 			barrel = Barrel.Current;
+		}
+	}
+	public partial class CustomDirBarrelTests
+	{
+		public override void SetupBarrel()
+		{
+			var dir = BarrelUtils.GetBasePath("com.refractored.monkeyfile.customdir");
+			this.barrel = Barrel.Create(dir);
 		}
 	}
 

--- a/src/MonkeyCache.TestsLiteDB/BarrelTests.cs
+++ b/src/MonkeyCache.TestsLiteDB/BarrelTests.cs
@@ -7,12 +7,21 @@ namespace MonkeyCache.Tests
 {
     public partial class BarrelTests
     {
-		void SetupBarrel()
+		public virtual void SetupBarrel()
 		{
 			Barrel.ApplicationId = "com.refractored.monkeylite";
 			barrel = Barrel.Current;
 		}
 	}
+	public partial class CustomDirBarrelTests
+	{
+		public override void SetupBarrel()
+		{
+			var dir = BarrelUtils.GetBasePath("com.refractored.monkeylite.customdir");
+			this.barrel = Barrel.Create(dir);
+		}
+	}
+
 	public partial class BarrelUtilTests
 	{
 		void SetupBarrel(ref IBarrel barrel)

--- a/src/MonkeyCache.TestsSQLite/BarrelTests.cs
+++ b/src/MonkeyCache.TestsSQLite/BarrelTests.cs
@@ -7,12 +7,22 @@ namespace MonkeyCache.Tests
 {
     public partial class BarrelTests
     {
-		void SetupBarrel()
+		public virtual void SetupBarrel()
 		{
 			Barrel.ApplicationId = "com.refractored.monkeysql";
 			barrel = Barrel.Current;
 		}
 	}
+
+	public partial class CustomDirBarrelTests
+	{
+		public override void SetupBarrel()
+		{
+			var dir = BarrelUtils.GetBasePath("com.refractored.monkeysql.customdir");
+			this.barrel = Barrel.Create(dir);
+		}
+	}
+
 	public partial class BarrelUtilTests
 	{
 		void SetupBarrel(ref IBarrel barrel)

--- a/src/MonkeyCache.TestsShared/BarrelTests.cs
+++ b/src/MonkeyCache.TestsShared/BarrelTests.cs
@@ -17,7 +17,7 @@ namespace MonkeyCache.Tests
 
         string url;
         string json;
-        IBarrel barrel;
+        internal IBarrel barrel;
 
         [TestInitialize]
         public void Setup()
@@ -524,5 +524,10 @@ namespace MonkeyCache.Tests
 
 		[TestCleanup]
 		public void Teardown() => barrel?.EmptyAll();
+	}
+
+	[TestClass]
+	public partial class CustomDirBarrelTests : BarrelTests
+	{
 	}
 }


### PR DESCRIPTION
I have a use case where I would like to be able to create different instances of `Barrel` stored in different file locations.  For example, I want to store some items in a directory that's backed up to iCloud and others which are not.

This will allow me to do something like:
```csharp
var backedUpBarrel = Barrel.Create("/path/to/icloud/backed/data/");
var tempBarrel = Barrel.Create("/path/to/temp/location/");
```

Includes tests for using the `Barrel.Create` factory method (the tests just subclass the existing tests but the setup of the Barrel uses `Barrel.Create` instead of `Barrel.Current`).