### PR TITLE
Make Barrel and HttpCache singletons thread-safe

### DIFF
--- a/src/MonkeyCache.FileStore/Barrel.cs
+++ b/src/MonkeyCache.FileStore/Barrel.cs
@@ -43,12 +43,12 @@ namespace MonkeyCache.FileStore
 
 		public bool AutoExpire { get ; set; }
 
-		static Barrel instance = null;
+		static readonly Lazy<Barrel> instance = new Lazy<Barrel>(() => new Barrel());
 
 		/// <summary>
 		/// Gets the instance of the Barrel
 		/// </summary>
-		public static IBarrel Current => (instance ?? (instance = new Barrel()));
+		public static IBarrel Current => instance.Value;
 
 		public static IBarrel Create(string cacheDirectory) =>
 			new Barrel(cacheDirectory);

--- a/src/MonkeyCache.LiteDB/Barrel.cs
+++ b/src/MonkeyCache.LiteDB/Barrel.cs
@@ -25,22 +25,22 @@ namespace MonkeyCache.LiteDB
 
 		public bool AutoExpire { get; set; }
 
-		static Barrel instance = null;
+		static Lazy<Barrel> instance = new Lazy<Barrel>(() => new Barrel());
 		static ILiteCollection<Banana> col;
 
 		/// <summary>
 		/// Gets the instance of the Barrel
 		/// </summary>
-		public static IBarrel Current => (instance ?? (instance = new Barrel()));
+		public static IBarrel Current => instance.Value;
 
 		public static IBarrel Create(string cacheDirectory, bool cache = false)
 		{
 			if (!cache)
 				return new Barrel(cacheDirectory);
 
-			if(instance == null)
-				instance = new Barrel(cacheDirectory);
-			return instance;
+			if(!instance.IsValueCreated)
+				instance = new Lazy<Barrel>(() => new Barrel(cacheDirectory));
+			return instance.Value;
 		}
 
 		readonly JsonSerializerSettings jsonSettings;

--- a/src/MonkeyCache.SQLite/Barrel.cs
+++ b/src/MonkeyCache.SQLite/Barrel.cs
@@ -25,12 +25,12 @@ namespace MonkeyCache.SQLite
 
 		public bool AutoExpire { get; set; }
 
-		static Barrel instance = null;
+		static readonly Lazy<Barrel> instance = new Lazy<Barrel>(() => new Barrel());
 
 		/// <summary>
 		/// Gets the instance of the Barrel
 		/// </summary>
-		public static IBarrel Current => (instance ?? (instance = new Barrel()));
+		public static IBarrel Current => instance.Value;
 
 		public static IBarrel Create(string cacheDirectory)
 			=> new Barrel(cacheDirectory);

--- a/src/MonkeyCache/HttpCache.cs
+++ b/src/MonkeyCache/HttpCache.cs
@@ -12,12 +12,12 @@ namespace MonkeyCache
 	public class HttpCache
 	{
 
-		static HttpCache instance = null;
+		static readonly Lazy<HttpCache> instance = new Lazy<HttpCache>(() => new HttpCache());
 
 		/// <summary>
 		/// Gets the instance of the HttpCache
 		/// </summary>
-		public static HttpCache Current => (instance ?? (instance = new HttpCache()));
+		public static HttpCache Current => instance.Value;
 
 		HttpCache()
 		{


### PR DESCRIPTION
Uses technique described by Jon Skeet here https://csharpindepth.com/articles/singleton#lazy
MSDN docs: https://docs.microsoft.com/en-us/dotnet/api/system.lazy-1

I couldn't test this on Android/iOS/macOS because I don't have a Xamarin development environment. Maybe you could test this with your neat Azure pipelines? Though feel free to decline this pull request if testing it would take too much of your time, since these changes usually aren't needed (I have a pretty specific use case where I need the singleton to be thread safe).