### PR TITLE
Update MonkeyCache to 2.0 and use System.Text.Json

### DIFF
--- a/src/MonkeyCache.FileStore/Barrel.cs
+++ b/src/MonkeyCache.FileStore/Barrel.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
-using Newtonsoft.Json;
 
 namespace MonkeyCache.FileStore
 {
 	public class Barrel : IBarrel
 	{
 		ReaderWriterLockSlim indexLocker;
-		readonly JsonSerializerSettings jsonSettings;
 		Lazy<string> baseDirectory;
 		HashAlgorithm hashAlgorithm;
 
@@ -35,13 +36,6 @@ namespace MonkeyCache.FileStore
 				hashAlgorithm = MD5.Create();
 
 			indexLocker = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
-
-			jsonSettings = new JsonSerializerSettings
-			{
-				ObjectCreationHandling = ObjectCreationHandling.Replace,
-				ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-				TypeNameHandling = TypeNameHandling.All,
-			};
 
 			index = new Dictionary<string, Tuple<string, DateTime>>();
 
@@ -68,14 +62,7 @@ namespace MonkeyCache.FileStore
 		public static IBarrel Create(string cacheDirectory, HashAlgorithm hash = null) =>
 			new Barrel(cacheDirectory, hash);
 
-		/// <summary>
-		/// Adds an entry to the barrel
-		/// </summary>
-		/// <param name="key">Unique identifier for the entry</param>
-		/// <param name="data">Data object to store</param>
-		/// <param name="expireIn">Time from UtcNow to expire entry in</param>
-		/// <param name="eTag">Optional eTag information</param>
-		void Add(string key, string data, TimeSpan expireIn, string eTag = null)
+		void Add(string key, string data, TimeSpan expireIn, string eTag)
 		{
 			indexLocker.EnterWriteLock();
 
@@ -99,41 +86,44 @@ namespace MonkeyCache.FileStore
 			}
 		}
 
-		/// <summary>
-		/// Adds an entry to the barrel
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="key">Unique identifier for the entry</param>
-		/// <param name="data">Data object to store</param>
-		/// <param name="expireIn">Time from UtcNow to expire entry in</param>
-		/// <param name="eTag">Optional eTag information</param>
-		/// <param name="jsonSerializationSettings">Custom json serialization settings to use</param>
-		public void Add<T>(string key, 
-							T data, 
-							TimeSpan expireIn, 
-							string eTag = null,
-							JsonSerializerSettings jsonSerializationSettings = null)
+		void Add<T>(
+			string key,
+			T data,
+			TimeSpan expireIn,
+			string eTag,
+			Func<T, string> serializer)
 		{
-
 			if (string.IsNullOrWhiteSpace(key))
 				throw new ArgumentException("Key can not be null or empty.", nameof(key));
 
 			if (data == null)
 				throw new ArgumentNullException("Data can not be null.", nameof(data));
 
-			var dataJson = string.Empty;
-
+			string dataJson;
 			if (BarrelUtils.IsString(data))
 			{
 				dataJson = data as string;
 			}
 			else
 			{
-				dataJson = JsonConvert.SerializeObject(data, jsonSerializationSettings ?? jsonSettings);
+				dataJson = serializer(data);
 			}
 
 			Add(key, dataJson, expireIn, eTag);
 		}
+
+		/// <inheritdoc/>
+		[RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")]
+		public void Add<T>(string key, T data, TimeSpan expireIn, JsonSerializerOptions options = null, string eTag = null) =>
+			Add(key, data, expireIn, eTag, data => JsonSerialize(data, options));
+
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Workaround https://github.com/dotnet/linker/issues/2001")]
+		static string JsonSerialize<T>(T data, JsonSerializerOptions options) =>
+			JsonSerializer.Serialize(data, options);
+
+		/// <inheritdoc/>
+		public void Add<T>(string key, T data, TimeSpan expireIn, JsonTypeInfo<T> jsonTypeInfo, string eTag = null) =>
+			Add(key, data, expireIn, eTag, data => JsonSerializer.Serialize(data, jsonTypeInfo));
 
 		/// <summary>
 		/// Empties all specified entries regardless if they are expired.
@@ -152,7 +142,7 @@ namespace MonkeyCache.FileStore
 						continue;
 
 					var file = Path.Combine(baseDirectory.Value, Hash(k));
-					if(File.Exists(file))
+					if (File.Exists(file))
 						File.Delete(file);
 
 					index.Remove(k);
@@ -180,7 +170,7 @@ namespace MonkeyCache.FileStore
 				{
 					var hash = Hash(item.Key);
 					var file = Path.Combine(baseDirectory.Value, hash);
-					if(File.Exists(file))
+					if (File.Exists(file))
 						File.Delete(file);
 				}
 
@@ -295,13 +285,7 @@ namespace MonkeyCache.FileStore
 			}
 		}
 
-		/// <summary>
-		/// Gets the data entry for the specified key.
-		/// </summary>
-		/// <param name="key">Unique identifier for the entry to get</param>
-		/// <param name="jsonSerializationSettings">Custom json serialization settings to use</param>
-		/// <returns>The data object that was stored if found, else default(T)</returns>
-		public T Get<T>(string key, JsonSerializerSettings jsonSerializationSettings = null)
+		T Get<T>(string key, Func<string, T> deserialize)
 		{
 			if (string.IsNullOrWhiteSpace(key))
 				throw new ArgumentException("Key can not be null or empty.", nameof(key));
@@ -324,7 +308,7 @@ namespace MonkeyCache.FileStore
 						return (T)final;
 					}
 
-					result = JsonConvert.DeserializeObject<T>(contents, jsonSerializationSettings ?? jsonSettings);
+					result = deserialize(contents);
 				}
 			}
 			finally
@@ -334,6 +318,19 @@ namespace MonkeyCache.FileStore
 
 			return result;
 		}
+
+		/// <inheritdoc/>
+		[RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")]
+		public T Get<T>(string key, JsonSerializerOptions options = null) =>
+			Get(key, contents => JsonDeserialize<T>(contents, options));
+
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Workaround https://github.com/dotnet/linker/issues/2001")]
+		static T JsonDeserialize<T>(string contents, JsonSerializerOptions options) =>
+			JsonSerializer.Deserialize<T>(contents, options);
+
+		/// <inheritdoc/>
+		public T Get<T>(string key, JsonTypeInfo<T> jsonTypeInfo) => Get(key, contents =>
+			JsonSerializer.Deserialize(contents, jsonTypeInfo));
 
 		/// <summary>
 		/// Gets the DateTime that the item will expire for the specified key.

--- a/src/MonkeyCache.FileStore/MonkeyCache.FileStore.csproj
+++ b/src/MonkeyCache.FileStore/MonkeyCache.FileStore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<TargetFramework>net6.0</TargetFramework>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>2.0.0.0</AssemblyVersion>
 		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
@@ -48,14 +48,6 @@
 	<ItemGroup Condition=" '$(Configuration)'=='Release' And '$(OS)' == 'Windows_NT' ">
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
-
-	<PropertyGroup>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</TargetPlatformMinVersion>
-	</PropertyGroup>
 
 	<ItemGroup>
 		<Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />

--- a/src/MonkeyCache.FileStore/MonkeyCache.FileStore.csproj
+++ b/src/MonkeyCache.FileStore/MonkeyCache.FileStore.csproj
@@ -1,36 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+	<PropertyGroup>
 		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
-    <Version>2.0.0.0</Version>
-    <PackageVersion>2.0.0.0</PackageVersion>
-    <Authors>James Montemagno</Authors>
-    <PackageId>MonkeyCache.FileStore</PackageId>
-    <PackOnBuild>true</PackOnBuild>
-    <PackageIconUrl>https://raw.githubusercontent.com/jamesmontemagno/monkey-cache/master/art/MonkeyCacheSmall.png</PackageIconUrl>
-    <NeutralLanguage>en</NeutralLanguage>
-    <PackageLicenseUrl>https://github.com/jamesmontemagno/monkey-cache/blob/master/LICENSE</PackageLicenseUrl>
-    <Owners>James Montemagno</Owners>
-    <PackageProjectUrl>https://github.com/jamesmontemagno/monkey-cache</PackageProjectUrl>
-    <Summary>A simple caching library to cache any data structure for a specific amount of time in any .NET application.</Summary>
-    <PackageTags>xamarin, windows, ios, android, cache, http</PackageTags>
-    <Title>🙈 MonkeyCache.FileStore - A .NET Caching Library</Title>
-    <Description>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Additionally, offers simple HTTP methods for caching web request data. Powered by FileStore.</Description>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+		<Version>2.0.0.0</Version>
+		<PackageVersion>2.0.0.0</PackageVersion>
+		<Authors>James Montemagno</Authors>
+		<PackageId>MonkeyCache.FileStore</PackageId>
+		<PackOnBuild>true</PackOnBuild>
+		<PackageIconUrl>https://raw.githubusercontent.com/jamesmontemagno/monkey-cache/master/art/MonkeyCacheSmall.png</PackageIconUrl>
+		<NeutralLanguage>en</NeutralLanguage>
+		<PackageLicenseUrl>https://github.com/jamesmontemagno/monkey-cache/blob/master/LICENSE</PackageLicenseUrl>
+		<Owners>James Montemagno</Owners>
+		<PackageProjectUrl>https://github.com/jamesmontemagno/monkey-cache</PackageProjectUrl>
+		<Summary>A simple caching library to cache any data structure for a specific amount of time in any .NET application.</Summary>
+		<PackageTags>xamarin, windows, ios, android, cache, http</PackageTags>
+		<Title>🙈 MonkeyCache.FileStore - A .NET Caching Library</Title>
+		<Description>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Additionally, offers simple HTTP methods for caching web request data. Powered by FileStore.</Description>
 
-    <PackageReleaseNotes>See: https://github.com/jamesmontemagno/monkey-cache </PackageReleaseNotes>
-    <RepositoryUrl>https://github.com/jamesmontemagno/monkey-cache</RepositoryUrl>
-    <Copyright>2022 Refractored LLC &amp; James Montemagno</Copyright>
+		<PackageReleaseNotes>See: https://github.com/jamesmontemagno/monkey-cache </PackageReleaseNotes>
+		<RepositoryUrl>https://github.com/jamesmontemagno/monkey-cache</RepositoryUrl>
+		<Copyright>2022 Refractored LLC &amp; James Montemagno</Copyright>
 
-    <RootNamespace>MonkeyCache.FileStore</RootNamespace>
+		<RootNamespace>MonkeyCache.FileStore</RootNamespace>
 
-    <LangVersion>default</LangVersion>
+		<LangVersion>default</LangVersion>
 
-    <DefineConstants>$(DefineConstants);FILESTORE</DefineConstants>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+		<DefineConstants>$(DefineConstants);FILESTORE</DefineConstants>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>
 		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
@@ -58,11 +58,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    <Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />
-  </ItemGroup>
+		<Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\MonkeyCache\MonkeyCache.csproj" />
+	<ItemGroup>
+		<ProjectReference Include="..\MonkeyCache\MonkeyCache.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/MonkeyCache.FileStore/MonkeyCache.FileStore.csproj
+++ b/src/MonkeyCache.FileStore/MonkeyCache.FileStore.csproj
@@ -1,13 +1,12 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;MonoAndroid10.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.19041;net6.0-windows10.0.19041;net461</TargetFrameworks>
-	<Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>1.0.0.0</Version>
-    <PackageVersion>1.0.0.0</PackageVersion>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+    <Version>2.0.0.0</Version>
+    <PackageVersion>2.0.0.0</PackageVersion>
     <Authors>James Montemagno</Authors>
     <PackageId>MonkeyCache.FileStore</PackageId>
     <PackOnBuild>true</PackOnBuild>
@@ -33,6 +32,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>
+		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
 		<DebugSymbols>true</DebugSymbols>
@@ -50,29 +50,19 @@
 	</ItemGroup>
 
 	<PropertyGroup>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-tvos'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-macos'))">10.14</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</TargetPlatformMinVersion>
 	</PropertyGroup>
-	<PropertyGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-		<TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
+	<ItemGroup>
     <Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MonkeyCache\MonkeyCache.csproj" />
-		<Reference Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' " Include="netstandard" />
 	</ItemGroup>
 
 </Project>

--- a/src/MonkeyCache.LiteDB/Barrel.cs
+++ b/src/MonkeyCache.LiteDB/Barrel.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using LiteDB;
-using Newtonsoft.Json;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace MonkeyCache.LiteDB
 {
@@ -44,7 +47,6 @@ namespace MonkeyCache.LiteDB
 			return instance;
 		}
 
-		readonly JsonSerializerSettings jsonSettings;
 		Barrel(string cacheDirectory = null)
 		{
 			var directory = string.IsNullOrEmpty(cacheDirectory) ? baseCacheDir.Value : cacheDirectory;
@@ -72,13 +74,6 @@ namespace MonkeyCache.LiteDB
 
 			db = new LiteDatabase(path);
 			col = db.GetCollection<Banana>();
-
-			jsonSettings = new JsonSerializerSettings
-			{
-				ObjectCreationHandling = ObjectCreationHandling.Replace,
-				ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-				TypeNameHandling = TypeNameHandling.All,
-			};
 		}
 
 #region Exist and Expiration Methods
@@ -148,13 +143,7 @@ namespace MonkeyCache.LiteDB
 			return new string[0];
 		}
 
-		/// <summary>
-		/// Gets the data entry for the specified key.
-		/// </summary>
-		/// <param name="key">Unique identifier for the entry to get</param>
-		/// <param name="jsonSerializationSettings">Custom json serialization settings to use</param>
-		/// <returns>The data object that was stored if found, else default(T)</returns>
-		public T Get<T>(string key, JsonSerializerSettings jsonSerializationSettings = null)
+		T Get<T>(string key, Func<string, T> deserialize)
 		{
 			if (string.IsNullOrWhiteSpace(key))
 				throw new ArgumentException("Key can not be null or empty.", nameof(key));
@@ -172,9 +161,21 @@ namespace MonkeyCache.LiteDB
 				return (T)final;
 			}
 
-			return JsonConvert.DeserializeObject<T>(ent.Contents, jsonSerializationSettings ?? jsonSettings);
+			return deserialize(ent.Contents);
 		}
 
+		/// <inheritdoc/>
+		[RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")]
+		public T Get<T>(string key, JsonSerializerOptions options = null) =>
+			Get(key, contents => JsonDeserialize<T>(contents, options));
+
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Workaround https://github.com/dotnet/linker/issues/2001")]
+		private static T JsonDeserialize<T>(string contents, JsonSerializerOptions options) =>
+			JsonSerializer.Deserialize<T>(contents, options);
+
+		/// <inheritdoc/>
+		public T Get<T>(string key, JsonTypeInfo<T> jsonTypeInfo) =>
+			Get(key, contents => JsonSerializer.Deserialize(contents, jsonTypeInfo));
 
 		/// <summary>
 		/// Gets the ETag for the specified key.
@@ -216,15 +217,7 @@ namespace MonkeyCache.LiteDB
 
 #region Add Methods
 
-		/// <summary>
-		/// Adds a string netry to the barrel
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="key">Unique identifier for the entry</param>
-		/// <param name="data">Data string to store</param>
-		/// <param name="expireIn">Time from UtcNow to expire entry in</param>
-		/// <param name="eTag">Optional eTag information</param>
-		void Add(string key, string data, TimeSpan expireIn, string eTag = null)
+		void Add(string key, string data, TimeSpan expireIn, string eTag)
 		{
 			if (data == null)
 				return;
@@ -240,16 +233,7 @@ namespace MonkeyCache.LiteDB
 			col.Upsert(ent);
 		}
 
-		/// <summary>
-		/// Adds an entry to the barrel
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="key">Unique identifier for the entry</param>
-		/// <param name="data">Data object to store</param>
-		/// <param name="expireIn">Time from UtcNow to expire entry in</param>
-		/// <param name="eTag">Optional eTag information</param>
-		/// <param name="jsonSerializationSettings">Custom json serialization settings to use</param>
-		public void Add<T>(string key, T data, TimeSpan expireIn, string eTag = null, JsonSerializerSettings jsonSerializationSettings = null)
+		void Add<T>(string key, T data, TimeSpan expireIn, string eTag, Func<T, string> serializer)
 		{
 			if (string.IsNullOrWhiteSpace(key))
 				throw new ArgumentException("Key can not be null or empty.", nameof(key));
@@ -257,19 +241,31 @@ namespace MonkeyCache.LiteDB
 			if (data == null)
 				throw new ArgumentNullException("Data can not be null.", nameof(data));
 
-			var dataJson = string.Empty;
-
+			string dataJson;
 			if (BarrelUtils.IsString(data))
 			{
 				dataJson = data as string;
 			}
 			else
 			{
-				dataJson = JsonConvert.SerializeObject(data, jsonSerializationSettings ?? jsonSettings);
+				dataJson = serializer(data);
 			}
 
 			Add(key, dataJson, expireIn, eTag);
 		}
+
+		/// <inheritdoc/>
+		[RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")]
+		public void Add<T>(string key, T data, TimeSpan expireIn, JsonSerializerOptions options = null, string eTag = null) =>
+			Add(key, data, expireIn, eTag, data => JsonSerialize(data, options));
+
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Workaround https://github.com/dotnet/linker/issues/2001")]
+		static string JsonSerialize<T>(T data, JsonSerializerOptions options) =>
+			JsonSerializer.Serialize(data, options);
+
+		/// <inheritdoc/>
+		public void Add<T>(string key, T data, TimeSpan expireIn, JsonTypeInfo<T> jsonTypeInfo, string eTag = null) =>
+			Add(key, data, expireIn, eTag, data => JsonSerializer.Serialize(data, jsonTypeInfo));
 
 		#endregion
 

--- a/src/MonkeyCache.LiteDB/Barrel.cs
+++ b/src/MonkeyCache.LiteDB/Barrel.cs
@@ -56,19 +56,14 @@ namespace MonkeyCache.LiteDB
 				Directory.CreateDirectory(directory);
 			}
 
-#if __MACOS__
-
-			if (!string.IsNullOrWhiteSpace(EncryptionKey))
-				path = $"Filename={path}; Password={EncryptionKey}; Mode=Exclusive";
-			else
-				path = $"Filename={path}; Mode=Exclusive";
-#else
-			
 			if (!string.IsNullOrWhiteSpace(EncryptionKey))
 				path = $"Filename={path}; Password={EncryptionKey}";
 			else
 				path = $"Filename={path}";
-#endif
+
+			if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst())
+				path += "; Mode=Exclusive";
+
 			if(Upgrade)
 				path += "; Upgrade=true";
 

--- a/src/MonkeyCache.LiteDB/MonkeyCache.LiteDB.csproj
+++ b/src/MonkeyCache.LiteDB/MonkeyCache.LiteDB.csproj
@@ -1,35 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+	<PropertyGroup>
 		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
-    <Version>2.0.0.0</Version>
-    <PackageVersion>2.0.0.0</PackageVersion>
-    <Authors>James Montemagno</Authors>
-    <PackageId>MonkeyCache.LiteDB</PackageId>
-    <PackOnBuild>true</PackOnBuild>
-    <PackageIconUrl>https://raw.githubusercontent.com/jamesmontemagno/monkey-cache/master/art/MonkeyCacheSmall.png</PackageIconUrl>
-    <NeutralLanguage>en</NeutralLanguage>
-    <PackageLicenseUrl>https://github.com/jamesmontemagno/monkey-cache/blob/master/LICENSE</PackageLicenseUrl>
-    <Owners>James Montemagno</Owners>
-    <PackageProjectUrl>https://github.com/jamesmontemagno/monkey-cache</PackageProjectUrl>
-    <Summary>A simple caching library to cache any data structure for a specific amount of time in any .NET application.</Summary>
-    <PackageTags>xamarin, windows, ios, android, cache, http</PackageTags>
-    <Title>🙉 MonkeyCache.LiteDB - A .NET Caching Library</Title>
-    <Description>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Additionally, offers simple HTTP methods for caching web request data. Powered by LiteDB.</Description>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+		<Version>2.0.0.0</Version>
+		<PackageVersion>2.0.0.0</PackageVersion>
+		<Authors>James Montemagno</Authors>
+		<PackageId>MonkeyCache.LiteDB</PackageId>
+		<PackOnBuild>true</PackOnBuild>
+		<PackageIconUrl>https://raw.githubusercontent.com/jamesmontemagno/monkey-cache/master/art/MonkeyCacheSmall.png</PackageIconUrl>
+		<NeutralLanguage>en</NeutralLanguage>
+		<PackageLicenseUrl>https://github.com/jamesmontemagno/monkey-cache/blob/master/LICENSE</PackageLicenseUrl>
+		<Owners>James Montemagno</Owners>
+		<PackageProjectUrl>https://github.com/jamesmontemagno/monkey-cache</PackageProjectUrl>
+		<Summary>A simple caching library to cache any data structure for a specific amount of time in any .NET application.</Summary>
+		<PackageTags>xamarin, windows, ios, android, cache, http</PackageTags>
+		<Title>🙉 MonkeyCache.LiteDB - A .NET Caching Library</Title>
+		<Description>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Additionally, offers simple HTTP methods for caching web request data. Powered by LiteDB.</Description>
 
-    <PackageReleaseNotes>See: https://github.com/jamesmontemagno/monkey-cache </PackageReleaseNotes>
-    <RepositoryUrl>https://github.com/jamesmontemagno/monkey-cache</RepositoryUrl>
-    <Copyright>2022 Refractored LLC &amp; James Montemagno</Copyright>
-    
-    <RootNamespace>MonkeyCache.LiteDB</RootNamespace>
+		<PackageReleaseNotes>See: https://github.com/jamesmontemagno/monkey-cache </PackageReleaseNotes>
+		<RepositoryUrl>https://github.com/jamesmontemagno/monkey-cache</RepositoryUrl>
+		<Copyright>2022 Refractored LLC &amp; James Montemagno</Copyright>
 
-    <LangVersion>default</LangVersion>
+		<RootNamespace>MonkeyCache.LiteDB</RootNamespace>
 
-    <DefineConstants>$(DefineConstants);LITEDB</DefineConstants>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<LangVersion>default</LangVersion>
+
+		<DefineConstants>$(DefineConstants);LITEDB</DefineConstants>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>
 		<IsTrimmable>true</IsTrimmable>
@@ -58,14 +58,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="LiteDB" Version="5.0.11" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />
 	</ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\MonkeyCache\MonkeyCache.csproj" />
-  </ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\MonkeyCache\MonkeyCache.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/MonkeyCache.LiteDB/MonkeyCache.LiteDB.csproj
+++ b/src/MonkeyCache.LiteDB/MonkeyCache.LiteDB.csproj
@@ -1,13 +1,12 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;MonoAndroid10.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.19041;net6.0-windows10.0.19041;net461</TargetFrameworks>
-	<Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>1.0.0.0</Version>
-    <PackageVersion>1.0.0.0</PackageVersion>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+    <Version>2.0.0.0</Version>
+    <PackageVersion>2.0.0.0</PackageVersion>
     <Authors>James Montemagno</Authors>
     <PackageId>MonkeyCache.LiteDB</PackageId>
     <PackOnBuild>true</PackOnBuild>
@@ -33,6 +32,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>
+		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
 		<DebugSymbols>true</DebugSymbols>
@@ -49,28 +49,19 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 	<PropertyGroup>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-tvos'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-macos'))">10.14</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</TargetPlatformMinVersion>
 	</PropertyGroup>
-	<PropertyGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-		<TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-	</PropertyGroup>
-
-
 
 	<ItemGroup>
 		<PackageReference Include="LiteDB" Version="5.0.11" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
   <ItemGroup>
     <Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />
-		<Reference Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' " Include="netstandard" />
 	</ItemGroup>
   
   <ItemGroup>

--- a/src/MonkeyCache.LiteDB/MonkeyCache.LiteDB.csproj
+++ b/src/MonkeyCache.LiteDB/MonkeyCache.LiteDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<TargetFramework>net6.0</TargetFramework>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>2.0.0.0</AssemblyVersion>
 		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
@@ -48,13 +48,6 @@
 	<ItemGroup Condition=" '$(Configuration)'=='Release' And '$(OS)' == 'Windows_NT' ">
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
-	<PropertyGroup>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</TargetPlatformMinVersion>
-	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="LiteDB" Version="5.0.11" />

--- a/src/MonkeyCache.SQLite/MonkeyCache.SQLite.csproj
+++ b/src/MonkeyCache.SQLite/MonkeyCache.SQLite.csproj
@@ -1,13 +1,11 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;MonoAndroid10.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.19041;net6.0-windows10.0.19041;net461</TargetFrameworks>
-	<Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>1.0.0.0</Version>
-    <PackageVersion>1.0.0.0</PackageVersion>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>	<Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+    <Version>2.0.0.0</Version>
+    <PackageVersion>2.0.0.0</PackageVersion>
     <Authors>James Montemagno</Authors>
     <PackageId>MonkeyCache.SQLite</PackageId>
     <PackOnBuild>true</PackOnBuild>
@@ -31,6 +29,7 @@
     <RootNamespace>MonkeyCache.SQLite</RootNamespace>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>
+		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
 		<DebugSymbols>true</DebugSymbols>
@@ -47,29 +46,20 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 	<PropertyGroup>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-tvos'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-macos'))">10.14</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</TargetPlatformMinVersion>
 	</PropertyGroup>
-	<PropertyGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-		<TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-	</PropertyGroup>
 
-  <ItemGroup>
-	 <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<Reference Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' " Include="netstandard" />
+	<ItemGroup>
+		<PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MonkeyCache\MonkeyCache.csproj" />
   </ItemGroup>
-
-
 
   <ItemGroup>
     <Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />

--- a/src/MonkeyCache.SQLite/MonkeyCache.SQLite.csproj
+++ b/src/MonkeyCache.SQLite/MonkeyCache.SQLite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<TargetFramework>net6.0</TargetFramework>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>2.0.0.0</AssemblyVersion>
 		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
@@ -46,13 +46,6 @@
 	<ItemGroup Condition=" '$(Configuration)'=='Release' And '$(OS)' == 'Windows_NT' ">
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
-	<PropertyGroup>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</TargetPlatformMinVersion>
-	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="sqlite-net-pcl" Version="1.8.116" />

--- a/src/MonkeyCache.SQLite/MonkeyCache.SQLite.csproj
+++ b/src/MonkeyCache.SQLite/MonkeyCache.SQLite.csproj
@@ -1,33 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>	<Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
-    <Version>2.0.0.0</Version>
-    <PackageVersion>2.0.0.0</PackageVersion>
-    <Authors>James Montemagno</Authors>
-    <PackageId>MonkeyCache.SQLite</PackageId>
-    <PackOnBuild>true</PackOnBuild>
-    <PackageIconUrl>https://raw.githubusercontent.com/jamesmontemagno/monkey-cache/master/art/MonkeyCacheSmall.png</PackageIconUrl>
-    <NeutralLanguage>en</NeutralLanguage>
-    <PackageLicenseUrl>https://github.com/jamesmontemagno/monkey-cache/blob/master/LICENSE</PackageLicenseUrl>
-    <Owners>James Montemagno</Owners>
-    <PackageProjectUrl>https://github.com/jamesmontemagno/monkey-cache</PackageProjectUrl>
-    <Summary>A simple caching library to cache any data structure for a specific amount of time in any .NET application.</Summary>
-    <PackageTags>xamarin, windows, ios, android, cache, http</PackageTags>
-    <Title>🙊 MonkeyCache.SQLite - A .NET Caching Library</Title>
-    <Description>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Additionally, offers simple HTTP methods for caching web request data. Powered by SQLite.</Description>
-    <Copyright>2022 Refractored LLC &amp; James Montemagno</Copyright>
-    <RepositoryUrl>https://github.com/jamesmontemagno/monkey-cache</RepositoryUrl>
-    <PackageReleaseNotes>See: https://github.com/jamesmontemagno/monkey-cache </PackageReleaseNotes>
-    
-    <LangVersion>default</LangVersion>
+	<PropertyGroup>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<Product>$(AssemblyName) ($(TargetFramework))</Product>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+		<Version>2.0.0.0</Version>
+		<PackageVersion>2.0.0.0</PackageVersion>
+		<Authors>James Montemagno</Authors>
+		<PackageId>MonkeyCache.SQLite</PackageId>
+		<PackOnBuild>true</PackOnBuild>
+		<PackageIconUrl>https://raw.githubusercontent.com/jamesmontemagno/monkey-cache/master/art/MonkeyCacheSmall.png</PackageIconUrl>
+		<NeutralLanguage>en</NeutralLanguage>
+		<PackageLicenseUrl>https://github.com/jamesmontemagno/monkey-cache/blob/master/LICENSE</PackageLicenseUrl>
+		<Owners>James Montemagno</Owners>
+		<PackageProjectUrl>https://github.com/jamesmontemagno/monkey-cache</PackageProjectUrl>
+		<Summary>A simple caching library to cache any data structure for a specific amount of time in any .NET application.</Summary>
+		<PackageTags>xamarin, windows, ios, android, cache, http</PackageTags>
+		<Title>🙊 MonkeyCache.SQLite - A .NET Caching Library</Title>
+		<Description>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Additionally, offers simple HTTP methods for caching web request data. Powered by SQLite.</Description>
+		<Copyright>2022 Refractored LLC &amp; James Montemagno</Copyright>
+		<RepositoryUrl>https://github.com/jamesmontemagno/monkey-cache</RepositoryUrl>
+		<PackageReleaseNotes>See: https://github.com/jamesmontemagno/monkey-cache </PackageReleaseNotes>
 
-    <DefineConstants>$(DefineConstants);SQLITE</DefineConstants>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <RootNamespace>MonkeyCache.SQLite</RootNamespace>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+		<LangVersion>default</LangVersion>
+
+		<DefineConstants>$(DefineConstants);SQLITE</DefineConstants>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<RootNamespace>MonkeyCache.SQLite</RootNamespace>
+		<GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>
 		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
@@ -55,13 +56,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
-  </ItemGroup>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\MonkeyCache\MonkeyCache.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\MonkeyCache\MonkeyCache.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\MonkeyCache.Shared\**\*.cs" LinkBase="Shared" />
+	</ItemGroup>
 </Project>

--- a/src/MonkeyCache.TestsFileStore/MonkeyCache.TestsFileStore.csproj
+++ b/src/MonkeyCache.TestsFileStore/MonkeyCache.TestsFileStore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MonkeyCache.TestsLiteDB/MonkeyCache.TestsLiteDB.csproj
+++ b/src/MonkeyCache.TestsLiteDB/MonkeyCache.TestsLiteDB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MonkeyCache.TestsSQLite/MonkeyCache.TestsSQLite.csproj
+++ b/src/MonkeyCache.TestsSQLite/MonkeyCache.TestsSQLite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -20,7 +20,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
   </ItemGroup>
 

--- a/src/MonkeyCache/BarrelUtils.cs
+++ b/src/MonkeyCache/BarrelUtils.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
-#if __IOS__ || __MACOS__
+#if IOS || MACOS || MACCATALYST
 using Foundation;
-#elif __ANDROID__
+#elif ANDROID
 using Android.App;
 #endif
 
@@ -54,19 +54,19 @@ namespace MonkeyCache
 
 			if (applicationId.IndexOfAny(Path.GetInvalidPathChars()) != -1)
 				throw new ArgumentException("ApplicationId has invalid characters");
-			
+
 			if (string.IsNullOrWhiteSpace(basePath))
 			{
 				// Gets full path based on device type.
-	#if __IOS__ || __MACOS__
+#if IOS || MACCATALYST
 				basePath = NSSearchPath.GetDirectories(NSSearchPathDirectory.CachesDirectory, NSSearchPathDomain.User)[0];
-	#elif __ANDROID__
+#elif ANDROID
 				basePath = Application.Context.CacheDir.AbsolutePath;
-	#elif __UWP__ || WINDOWS
+#elif WINDOWS
 				basePath = Windows.Storage.ApplicationData.Current.LocalCacheFolder.Path;
-	#else
+#else
 				basePath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-	#endif
+#endif
 			}
 
 			return Path.Combine(basePath, applicationId);

--- a/src/MonkeyCache/HttpCache.cs
+++ b/src/MonkeyCache/HttpCache.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -75,6 +76,7 @@ namespace MonkeyCache
 		/// <param name="forceUpdate">If we should force the update or not</param>
 		/// <param name="throttled">If throttled or not</param>
 		/// <returns>The new or cached response.</returns>
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Only using string in IBarrel.Get and Add.")]
 		public static async Task<string> SendCachedAsync(this HttpClient http, IBarrel barrel, HttpRequestMessage req, TimeSpan expireIn, bool forceUpdate = false, bool throttled = true)
 		{
 			var url = req.RequestUri.ToString();
@@ -118,7 +120,7 @@ namespace MonkeyCache
 				// Cache it?
 				var newEtag = r.Headers.ETag != null ? r.Headers.ETag.Tag : null;
 				if (!string.IsNullOrEmpty(newEtag) && newEtag != etag)
-					barrel.Add(url, c, expireIn, newEtag);
+					barrel.Add(url, c, expireIn, eTag: newEtag);
 
 				return c;
 			} else {

--- a/src/MonkeyCache/IBarrel.cs
+++ b/src/MonkeyCache/IBarrel.cs
@@ -1,6 +1,8 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace MonkeyCache
 {
@@ -21,9 +23,21 @@ namespace MonkeyCache
 		/// <param name="key">Key to use</param>
 		/// <param name="data">Data to store of type T</param>
 		/// <param name="expireIn">How long in the future the item should expire</param>
+		/// <param name="options">Specific json serializer options to use</param>
 		/// <param name="eTag">eTag to use if needed</param>
-		/// <param name="jsonSerializationSettings">Specific json serialization to use</param>
-		void Add<T>(string key, T data, TimeSpan expireIn, string eTag = null, JsonSerializerSettings jsonSerializationSettings = null);
+		[RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")] 
+		void Add<T>(string key, T data, TimeSpan expireIn, JsonSerializerOptions options = null, string eTag = null);
+
+		/// <summary>
+		/// Add an item to the barrel
+		/// </summary>
+		/// <typeparam name="T">Type of item</typeparam>
+		/// <param name="key">Key to use</param>
+		/// <param name="data">Data to store of type T</param>
+		/// <param name="expireIn">How long in the future the item should expire</param>
+		/// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
+		/// <param name="eTag">eTag to use if needed</param>
+		void Add<T>(string key, T data, TimeSpan expireIn, JsonTypeInfo<T> jsonTypeInfo, string eTag = null);
 
 		/// <summary>
 		/// Empty a set of keys
@@ -54,18 +68,31 @@ namespace MonkeyCache
 		/// <param name="state">State to get: Multiple with flags: CacheState.Active | CacheState.Expired</param>
 		/// <returns>The keys</returns>
 		IEnumerable<string> GetKeys(CacheState state = CacheState.Active);
-		
+
 		/// <summary>
 		/// Get an object for the key
 		/// </summary>
 		/// <typeparam name="T">Type of object to get</typeparam>
 		/// <param name="key">Key to use</param>
-		/// <param name="jsonSettings">json serialization settings to use.</param>
+		/// <param name="options">Specific json serializer options to use</param>
 		/// <returns>The object back if it exists, else null</returns>
 		/// <remarks>
-		/// When AutoExpire is set to true, Get<T> will return NULL if the item is expired
+		/// When AutoExpire is set to true, Get{T} will return NULL if the item is expired
 		/// </remarks>
-		T Get<T>(string key, JsonSerializerSettings jsonSettings = null);
+		[RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")] 
+		T Get<T>(string key, JsonSerializerOptions options = null);
+
+		/// <summary>
+		/// Get an object for the key
+		/// </summary>
+		/// <typeparam name="T">Type of object to get</typeparam>
+		/// <param name="key">Key to use</param>
+		/// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
+		/// <returns>The object back if it exists, else null</returns>
+		/// <remarks>
+		/// When AutoExpire is set to true, Get{T} will return NULL if the item is expired
+		/// </remarks>
+		T Get<T>(string key, JsonTypeInfo<T> jsonTypeInfo);
 
 		/// <summary>
 		/// Get the eTag for a key

--- a/src/MonkeyCache/MonkeyCache.csproj
+++ b/src/MonkeyCache/MonkeyCache.csproj
@@ -1,12 +1,11 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;MonoAndroid10.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.19041;net6.0-windows10.0.19041;net461</TargetFrameworks>
-	<Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>1.0.0.0</Version>
-    <PackageVersion>1.0.0.0</PackageVersion>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+    <Version>2.0.0.0</Version>
+    <PackageVersion>2.0.0.0</PackageVersion>
     <Authors>James Montemagno</Authors>
     <PackageId>MonkeyCache</PackageId>
     <PackOnBuild>true</PackOnBuild>
@@ -30,6 +29,7 @@
     <RootNamespace>MonkeyCache</RootNamespace>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>
+		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
 		<DebugSymbols>true</DebugSymbols>
@@ -46,21 +46,14 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 	<PropertyGroup>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-tvos'))">10.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-macos'))">10.14</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-android'))">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-ios'))">10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-maccatalyst'))">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</TargetPlatformMinVersion>
 	</PropertyGroup>
-	<PropertyGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-		<TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-	</PropertyGroup>
 
-  <ItemGroup>
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<Reference Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' " Include="System.Net.Http" />
-		<Reference Condition=" '$(TargetFramework)' == 'net461' " Include="System.Net.Http" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+	</ItemGroup>
 </Project>

--- a/src/MonkeyCache/MonkeyCache.csproj
+++ b/src/MonkeyCache/MonkeyCache.csproj
@@ -1,33 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+	<PropertyGroup>
 		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
-    <Version>2.0.0.0</Version>
-    <PackageVersion>2.0.0.0</PackageVersion>
-    <Authors>James Montemagno</Authors>
-    <PackageId>MonkeyCache</PackageId>
-    <PackOnBuild>true</PackOnBuild>
-    <PackageIconUrl>https://raw.githubusercontent.com/jamesmontemagno/monkey-cache/master/art/MonkeyCacheSmall.png</PackageIconUrl>
-    <NeutralLanguage>en</NeutralLanguage>
-    <PackageLicenseUrl>https://github.com/jamesmontemagno/monkey-cache/blob/master/LICENSE</PackageLicenseUrl>
-    <Owners>James Montemagno</Owners>
-    <PackageProjectUrl>https://github.com/jamesmontemagno/monkey-cache</PackageProjectUrl>
-    <Summary>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Requires backend MonkeyCache package to be installed.</Summary>
-    <PackageTags>xamarin, windows, ios, android, cache, http</PackageTags>
-    <Title>🐒 MonkeyCache.Core - A .NET Caching Library</Title>
-    <Description>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Additionally, offers simple HTTP methods for caching web request data.</Description>
-    <Copyright>2022 Refractored LLC &amp; James Montemagno</Copyright>
-    <RepositoryUrl>https://github.com/jamesmontemagno/monkey-cache</RepositoryUrl>
-    <PackageReleaseNotes>See: https://github.com/jamesmontemagno/monkey-cache </PackageReleaseNotes>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+		<Version>2.0.0.0</Version>
+		<PackageVersion>2.0.0.0</PackageVersion>
+		<Authors>James Montemagno</Authors>
+		<PackageId>MonkeyCache</PackageId>
+		<PackOnBuild>true</PackOnBuild>
+		<PackageIconUrl>https://raw.githubusercontent.com/jamesmontemagno/monkey-cache/master/art/MonkeyCacheSmall.png</PackageIconUrl>
+		<NeutralLanguage>en</NeutralLanguage>
+		<PackageLicenseUrl>https://github.com/jamesmontemagno/monkey-cache/blob/master/LICENSE</PackageLicenseUrl>
+		<Owners>James Montemagno</Owners>
+		<PackageProjectUrl>https://github.com/jamesmontemagno/monkey-cache</PackageProjectUrl>
+		<Summary>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Requires backend MonkeyCache package to be installed.</Summary>
+		<PackageTags>xamarin, windows, ios, android, cache, http</PackageTags>
+		<Title>🐒 MonkeyCache.Core - A .NET Caching Library</Title>
+		<Description>A simple caching library to cache any data structure for a specific amount of time in any .NET application. Additionally, offers simple HTTP methods for caching web request data.</Description>
+		<Copyright>2022 Refractored LLC &amp; James Montemagno</Copyright>
+		<RepositoryUrl>https://github.com/jamesmontemagno/monkey-cache</RepositoryUrl>
+		<PackageReleaseNotes>See: https://github.com/jamesmontemagno/monkey-cache </PackageReleaseNotes>
 
-    <LangVersion>default</LangVersion>
+		<LangVersion>default</LangVersion>
 
-    <DefineConstants>$(DefineConstants);</DefineConstants>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <RootNamespace>MonkeyCache</RootNamespace>
-    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+		<DefineConstants>$(DefineConstants);</DefineConstants>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<RootNamespace>MonkeyCache</RootNamespace>
+		<GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>
 		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
@@ -52,8 +52,4 @@
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows10'))">10.0.16299.0</TargetPlatformMinVersion>
 	</PropertyGroup>
-
-	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-		<PackageReference Include="System.Text.Json" Version="6.0.2" />
-	</ItemGroup>
 </Project>

--- a/src/MonkeyCache/MonkeyCache.csproj
+++ b/src/MonkeyCache/MonkeyCache.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>2.0.0.0</AssemblyVersion>
 		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>

--- a/src/MonkeyCache/MonkeyCache.csproj
+++ b/src/MonkeyCache/MonkeyCache.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041</TargetFrameworks>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>2.0.0.0</AssemblyVersion>
 		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>


### PR DESCRIPTION
- Drop Newtonsoft and use System.Text.Json instead
    - Allow for source generators to be used in IBarrel
- Drop Xamarin TFMs and just target net6.0
- Mark MonkeyCache assemblies as IsTrimmable=true, so unused code can be trimmed

@jamesmontemagno 