### PR TITLE
AutoRebuildEnabled litedb

### DIFF
--- a/src/MonkeyCache.LiteDB/Barrel.cs
+++ b/src/MonkeyCache.LiteDB/Barrel.cs
@@ -19,6 +19,7 @@ namespace MonkeyCache.LiteDB
 		public static string ApplicationId { get; set; } = string.Empty;
 		public static string EncryptionKey { get; set; } = string.Empty;
 		public static bool Upgrade { get; set; } = false;
+		public static bool AutoRebuildEnabled { get; set; } = false;
 
 		static readonly Lazy<string> baseCacheDir = new Lazy<string>(() =>
 		{
@@ -66,6 +67,9 @@ namespace MonkeyCache.LiteDB
 
 			if(Upgrade)
 				path += "; Upgrade=true";
+
+			if (AutoRebuildEnabled)
+				path += "; auto-rebuild=true";
 
 			db = new LiteDatabase(path);
 			col = db.GetCollection<Banana>();

--- a/src/MonkeyCache.LiteDB/MonkeyCache.LiteDB.csproj
+++ b/src/MonkeyCache.LiteDB/MonkeyCache.LiteDB.csproj
@@ -50,7 +50,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="LiteDB" Version="5.0.13" />
+		<PackageReference Include="LiteDB" Version="5.0.19" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MonkeyCache.TestApp/MonkeyCache.TestApp.csproj
+++ b/src/MonkeyCache.TestApp/MonkeyCache.TestApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="5.0.13" />
+    <PackageReference Include="LiteDB" Version="5.0.19" />
     <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #137

Updated Barrel class and LiteDB package version

Updated the `Barrel` class in the `MonkeyCache.LiteDB` namespace to include a new static property `AutoRebuildEnabled` and modified the `LiteDatabase` instance creation code to append `"; auto-rebuild=true"` to the `path` variable if `AutoRebuildEnabled` is `true`. Also, updated the `LiteDB` package version in `MonkeyCache.LiteDB.csproj` from `5.0.13` to `5.0.19`.